### PR TITLE
Hide scrollbars in table container for cleaner UI

### DIFF
--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -8,7 +8,7 @@ function Table({ className, ...props }: React.ComponentProps<'table'>) {
   return (
     <div
       data-slot="table-container"
-      className="relative w-full overflow-x-auto"
+      className="relative w-full overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
     >
       <table
         data-slot="table"


### PR DESCRIPTION
## Summary
Updated the table container styling to hide scrollbars while maintaining horizontal scroll functionality, providing a cleaner visual appearance.

## Changes
- Added CSS classes to hide scrollbars in the table container:
  - `[scrollbar-width:none]` - Hides scrollbars in Firefox
  - `[&::-webkit-scrollbar]:hidden` - Hides scrollbars in Chrome, Safari, and other Webkit-based browsers
- The table remains horizontally scrollable on smaller viewports; only the scrollbar is visually hidden

## Implementation Details
- Used Tailwind CSS arbitrary value syntax for cross-browser scrollbar hiding
- Maintains the existing `overflow-x-auto` class to preserve scroll functionality
- This approach ensures consistent behavior across all modern browsers without requiring additional CSS files or JavaScript

https://claude.ai/code/session_01Lu8LtkN14GiA7CE2cJA3bF